### PR TITLE
fix: 검색 시 방금 올린 공고 못 찾는 이슈 해결

### DIFF
--- a/src/main/java/com/example/lablink/study/controller/StudyController.java
+++ b/src/main/java/com/example/lablink/study/controller/StudyController.java
@@ -65,7 +65,7 @@ public class StudyController {
         // searchOption 객체를 사용하여 검색 조건을 처리합니다.
         // pageIndex와 pageCount 파라미터는 기본값을 설정하여 받습니다.
         return ResponseMessage.SuccessResponse("조회 성공",
-                studySearchService.getStudies(searchOption, searchOption.getKeyword(), pageIndex, pageCount, sortedType, userDetails, companyDetails));
+                studySearchService.getStudies(searchOption, searchOption.getKeyword(), pageIndex-1, pageCount, sortedType, userDetails, companyDetails));
     }
 
     // done : ResponseEntity로

--- a/src/main/java/com/example/lablink/study/repository/StudyRepository.java
+++ b/src/main/java/com/example/lablink/study/repository/StudyRepository.java
@@ -22,7 +22,7 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
 
     List<Study> findAllByEmailSendIsFalse();
 
-    // todo : 방금 올린 공고 못 찾는 이슈 해결 ..
+    // done : 방금 올린 공고 못 찾는 이슈 해결 ..
 //    @Query(value = "ALTER TABLE study ADD FULLTEXT key (title, study_info, study_purpose, study_action)", nativeQuery = true);
 
     @Query(value = "SELECT * FROM study " +
@@ -32,7 +32,6 @@ public interface StudyRepository extends JpaRepository<Study, Long> {
             "AND (:searchTime IS NULL OR LOWER(date) LIKE LOWER(CONCAT('%', :searchTime, '%'))) " +
             "AND (:gender IS NULL OR LOWER(subject_gender) LIKE LOWER(CONCAT('%', :gender, '%'))) " +
             "AND ((:age IS NULL) OR ((:age >= subject_min_age) AND (:age <= subject_max_age))) " +
-            // todo : fulltext.. 123qweasd -> 123qwe으로 검색하면 안나옴 수정
             "AND (:keyword IS NULL OR LOWER(title) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
 //            "AND (:keyword IS NULL OR MATCH (title, study_info, study_purpose, study_action) AGAINST (:keyword IN BOOLEAN MODE)) " +
 //            "AND (:keyword IS NULL OR MATCH(title, study_info, study_purpose, study_action) AGAINST(:keyword IN BOOLEAN MODE)) " +

--- a/src/main/java/com/example/lablink/study/service/StudySearchService.java
+++ b/src/main/java/com/example/lablink/study/service/StudySearchService.java
@@ -79,6 +79,7 @@ public class StudySearchService {
         // 일반 전체 조회
         if(sortedType == null && !searchOption.hasValue()){
             studies = studyRepository.findAllByOrderByEndDateDesc();
+//            studies = studyRepository.findAll();
         }
 
         for (Study study : studies){
@@ -95,7 +96,6 @@ public class StudySearchService {
 
         return studyResponseDtos;
     }
-
     // 최근 검색 조회 (유저Id == key)
     // todo : 몇개까지 저장 ?
     /*public List<LatestSearchKeyword> latestSearchKeyword(UserDetailsImpl userDetails){
@@ -130,6 +130,7 @@ public class StudySearchService {
         return typedTuples.stream().map(SearchRankResponseDto::convertToResponseRankingDto).collect(Collectors.toList());
     }*/
 
+    @Transactional
     // 공고 정렬 조회
     public List<Study> getSortedStudies(String sortedType) {
         List<Study> studies = new ArrayList<>();

--- a/src/main/java/com/example/lablink/study/service/StudyService.java
+++ b/src/main/java/com/example/lablink/study/service/StudyService.java
@@ -193,6 +193,7 @@ public class StudyService {
     // xxx: isCompanyLogin() testcode짜려면 public으로 바꿔야하는데
     //  1. public으로 바꾸고 테스트코드 짜는게 좋을까
     //  2. private으로 하고 테스트코드 안짜는게 나을까?
+    @Transactional
     public Company isCompanyLogin(CompanyDetailsImpl companyDetails){
         if (companyDetails != null){
             return companyDetails.getCompany();
@@ -201,7 +202,7 @@ public class StudyService {
         }
     }
 
-
+    @Transactional
     // checkRole 게시글 권한 확인 (해당 게시글을 작성자와 똑같은지 확인)
     public void checkRole(Long studyId, Company company){
         studyRepository.findByIdAndCompany(studyId, company).orElseThrow(
@@ -209,6 +210,7 @@ public class StudyService {
         );
     }
 
+    @Transactional
     // 기업별 공고 찾기
     public List<Study> findAllCompanyStudy(Company company) {
         if (company == null) {
@@ -216,6 +218,8 @@ public class StudyService {
         }
         return studyRepository.findAllByCompany(company);
     }
+
+    @Transactional
 
     // todo : checkRole 이랑 동일
     // 기업이 작성한 공고 찾기


### PR DESCRIPTION
검색 시 방금 올린 공고 못 찾는 이슈 해결 
페이지네이션 위해서 걸어둔 limit 문제였음 

추후에 마지막 id 받아서 리팩토링 할 예정 